### PR TITLE
refactor: replace deprecated vim.tbl_flatten function

### DIFF
--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -64,7 +64,7 @@ M.path = (function()
   end
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten({ ... }), "/")
+    return vim.iter({ ... }):flatten():join("/")
   end
 
   -- Traverse the path calling cb along the way.
@@ -155,7 +155,7 @@ function M.search_ancestors(startpath, func)
 end
 
 function M.root_pattern(...)
-  local patterns = vim.tbl_flatten({ ... })
+  local patterns = vim.iter({ ... }):flatten()
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
       for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do


### PR DESCRIPTION
Replace the deprecated vim.tbl_flatten function (which will be removed with Neovim 0.13) by using new the iter() interface that came in Neovim 0.10.

---

(Copied from https://github.com/nvim-neotest/neotest-jest/pull/123).

Instead use a compatibility module so we don't break backwards compatibility.